### PR TITLE
Fix issue with incorrectly cut utf-8 strings.

### DIFF
--- a/inc/common.inc.php
+++ b/inc/common.inc.php
@@ -1643,7 +1643,7 @@ function hesk_input($in, $error = 0, $redirect_to = '', $force_slashes = 0, $max
 
     // Check length
     if ($max_length) {
-        $in = substr($in, 0, $max_length);
+        $in = mb_substr($in, 0, $max_length, "utf-8");
     }
 
     // Return processed value


### PR DESCRIPTION
PHP **substr** cuts UTF-8 encoded strings incorrectly which leads to issues with saving strings to database. 

```
sudo -u www-data /usr/bin/php /var/www/hesk/inc/mail/hesk_pop3.php
```

Here is an error message:

```
<b>Error:</b><br/><br/>
Can't execute SQL: 
	INSERT INTO `s4m_tickets`
	(
		`trackid`,
		`name`,
		`email`,
		`category`,
		`priority`,
		`subject`,
		`message`,
		`dt`,
		`lastchange`,
		`articles`,
		`ip`,
		`language`,
		`openedby`,
		`owner`,
		`attachments`,
		`merged`,
		`status`,
		`latitude`,
		`longitude`,
		`html`,
		`user_agent`,
		`screen_resolution_height`,
		`screen_resolution_width`,
		`due_date`,
		`history`
		, `custom1`, `custom2`, `custom3`, `custom4`, `custom5`, `custom6`, `custom7`, `custom8`, `custom9`, `custom10`, `custom11`, `custom12`, `custom13`, `custom14`, `custom15`, `custom16`, `custom17`, `custom18`, `custom19`, `custom20`, `custom21`, `custom22`, `custom23`, `custom24`, `custom25`, `custom26`, `custom27`, `custom28`, `custom29`, `custom30`, `custom31`, `custom32`, `custom33`, `custom34`, `custom35`, `custom36`, `custom37`, `custom38`, `custom39`, `custom40`, `custom41`, `custom42`, `custom43`, `custom44`, `custom45`, `custom46`, `custom47`, `custom48`, `custom49`, `custom50`
	)
	VALUES
	(
		'62W-D62-P75E',
		'Evgesha Bandenko',
		'xxxx@xxxx.com',
		'1',
		'2',
		'Я очень вас благодарю... За вашу чуткос�',
		'Здравствуйте, Техническая поддержка, <br />\n<br />\nДиагностическая информация(НЕ<br />\nУДАЛЯТЬ!):<br />\nAccount: mailto:xxxx@xxxx.com <br />\nDevice: 9A8C6CE8-4F2A-412F-9A30-A1C79700C6E8 <br />\nМодель устройства: iPhone<br />\n Операционная система: iPhone OS 7.1.2<br />\n Версия приложения: 1.2.14 <br />\n<br />\nПожалуйста, опишите проблему здесь: <br />\n<br />\nОтправлено с iPhone',
		NOW(),
		NOW(),
		NULL,
		'',
		'English',
		'-2',
		'7',
		'',
		'',
		'0',
		'',
		'',
		'0',
		'',
		NULL,
		NULL,
		NULL,
		''
		, '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', ''
	)
	</p><p>MySQL said:<br />Incorrect string value: '\xD1' for column 'subject' at row 1</p>
```
