### PR TITLE
Update preg_match to get working resend reply email

### DIFF
--- a/api/Link.php
+++ b/api/Link.php
@@ -87,7 +87,7 @@ class Link
 
             foreach ( $routes as $routePath => $routeDesc ){
                 $routePath = preg_replace( $regex, $replacements, $routePath );
-                if( preg_match( '#^/?' . $routePath . '/?$#', $path, $matches ) ){
+                if( preg_match( '#^/?' . $routePath . '/?#', $path, $matches ) ){
                     if( is_array( $routeDesc ) ) {
                         $handler = $routeDesc[0];
                         if( isset( $routeDesc[2] )) {


### PR DESCRIPTION
In https://developers.phpjunkyard.com/viewtopic.php?f=19&t=6444&p=27133 I explain that I get errors when trying to resend email replies. However deleting $ from the regexp, It will works fine.